### PR TITLE
chore: Use hotfix version of @crxjs/vite-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@crxjs/vite-plugin": "^2.0.0-beta.17",
+        "@crxjs/vite-plugin": "gist:a5beb6876d0f218e7551c303ffefa6ee",
         "@types/chrome": "^0.0.237",
         "@types/jquery": "^3.5.16",
         "@types/react": "^18.0.37",
@@ -39,9 +39,9 @@
     },
     "node_modules/@crxjs/vite-plugin": {
       "version": "2.0.0-beta.17",
-      "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.0.0-beta.17.tgz",
-      "integrity": "sha512-44CavnsY01jvF2uHfRdqA3j6bg6IcVc+ZrSayYS+H7eqb6BHWh619A2jJ3Y0eHVh9H65041ob4g6I1VMxWx4qw==",
+      "resolved": "git+ssh://git@gist.github.com/a5beb6876d0f218e7551c303ffefa6ee.git#d880debf1f0a0a67ca0e9aa39527d678eff22646",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
         "@webcomponents/custom-elements": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@crxjs/vite-plugin": "^2.0.0-beta.17",
+    "@crxjs/vite-plugin": "gist:a5beb6876d0f218e7551c303ffefa6ee",
     "@types/chrome": "^0.0.237",
     "@types/jquery": "^3.5.16",
     "@types/react": "^18.0.37",


### PR DESCRIPTION
Resolves #5 

Use temporary hosted plugin files: https://gist.github.com/nandenjin/a5beb6876d0f218e7551c303ffefa6ee