### PR TITLE
fix: Focus to document before copying URL and title

### DIFF
--- a/src/background/features/copyUrlAndTitle.ts
+++ b/src/background/features/copyUrlAndTitle.ts
@@ -77,6 +77,13 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
       const url = getPageURL()
       const title = getPageTitle()
 
+      // Check if the document has focus
+      if (!document.hasFocus()) {
+        // Attempt to focus the document
+        window.focus()
+        document.body.focus()
+      }
+
       // Copy URL and Title
       navigator.clipboard.writeText(`[${title} ${url}]`)
       console.log('Copied URL and Title')


### PR DESCRIPTION
Fixes #58

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nandenjin/tsukimi/pull/62?shareId=5191f6bd-020a-4a30-8208-19934db70f15).